### PR TITLE
Allow fcitx.el to work without evil installed

### DIFF
--- a/fcitx.el
+++ b/fcitx.el
@@ -213,9 +213,11 @@
      ((member key-seq fcitx--prefix-keys-sequence)
       (fcitx--prefix-keys-maybe-deactivate))
      ((and (equal (this-command-keys-vector) [])
-           (not (and evil-mode
+           (not (and (boundp 'evil-mode)
+                     evil-mode
                      (equal last-command 'switch-to-buffer)))
-           (not (and evil-mode
+           (not (and (boundp 'evil-mode)
+                     evil-mode
                      (equal last-command 'other-window)))
            (not (and fcitx--aggressive-p
                      (window-minibuffer-p))))


### PR DESCRIPTION
Before, fcitx.el checked the evil-mode variable to determine whether
evil-mode is turned on.  Without evil installed, though, this variable
does not exist, causing a `(void-variable evil-mode)` error every time
the prefix keys polling function is run.  This commit changes the
polling function to first check whether evil-mode is bound before
checking whether it is true or false.

I've tested this on Emacs 24.4 only, but the change shouldn't be version-specific.  I haven't, however, tested this patch with evil installed (it shouldn't break anything there, either, of course, but it might be good to check that).