### PR TITLE
the advice function "fcitx--evil-switch-buffer" should return the original retval

### DIFF
--- a/fcitx.el
+++ b/fcitx.el
@@ -358,9 +358,10 @@
   ;; before switch
   (fcitx--evil-switch-buffer-before)
   ;; switch buffer
-  (apply orig-func args)
-  ;; after switch
-  (fcitx--evil-switch-buffer-after))
+  (let ((retval (apply orig-func args)))
+    ;; after switch
+    (fcitx--evil-switch-buffer-after)
+    retval))
 
 (unless (fboundp 'advice-add)
   (defadvice switch-to-buffer (around fcitx--evil-switch-buffer-1)


### PR DESCRIPTION
Otherwise it would affect other functionality that relies on the return value of `switch-to-file` (and `find-file`, which relies on the former).