### PR TITLE
Call fcitx-remote directly, don't through shell

### DIFF
--- a/fcitx.el
+++ b/fcitx.el
@@ -231,14 +231,14 @@
  fcitx installtion.")))
 
 (defun fcitx--activate ()
-  (call-process-shell-command "fcitx-remote -o"))
+  (call-process "fcitx-remote" nil nil nil "-o"))
 
 (defun fcitx--deactivate ()
-  (call-process-shell-command "fcitx-remote -c"))
+  (call-process "fcitx-remote" nil nil nil "-c"))
 
 (defun fcitx--active-p ()
   (let ((output (with-temp-buffer
-                  (call-process-shell-command "fcitx-remote" nil t)
+                  (call-process "fcitx-remote" nil t)
                   (buffer-string))))
 
     (char-equal


### PR DESCRIPTION
Because it is not necessary, e.g., we don't need pipe output between commands, and it can improve performance:

```elisp
;; Original:
(measure-time (fcitx--active-p))
    ⇒ "0.033646"

;; This version:
(measure-time (fcitx--active-p))
    ⇒ "0.027410"

(defmacro measure-time (&rest body)
  "Measure the time it takes to evaluate BODY."
  `(let ((time (current-time)))
     ,@body
     (message "%.06f" (float-time (time-since time)))))
```

